### PR TITLE
Restore attributes on invalid transition

### DIFF
--- a/alexafsm/policy.py
+++ b/alexafsm/policy.py
@@ -38,6 +38,7 @@ class Policy:
             initial=states.attributes.state,
             auto_transitions=False
         )
+        self.attributes_backup = self.attributes
 
         for transition in transitions:
             self.machine.add_transition(**transition)
@@ -92,6 +93,8 @@ class Policy:
         """
         Update the session attributes with a request
         """
+        # backup attributes in case of invalid FSM transition
+        self.attributes_backup = self.attributes
         self.states.attributes = type(self.states.attributes).from_request(request)
         self.state = self.attributes.state
 
@@ -116,6 +119,8 @@ class Policy:
             return resp_function(self.states)
         except MachineError as exception:
             logger.error(str(exception))
+            # reset attributes
+            self.states.attributes = self.attributes_backup
             return response.NOT_UNDERSTOOD
 
     def handle(self, request: dict, voice_insights: VoiceInsights = None,


### PR DESCRIPTION
Otherwise, Alexa says "You asked for 'flowers'. The first of 12 skills is 1800 flowers..."

So you say "next skill", Amazon interprets that as a QuickSearch which is an invalid transition, Alexa tells user "Please say it differently", you say "what is the next skill?"

And *now* Alexa says "You asked for 'next skill', the second of 12 skills is Flora Facts..."